### PR TITLE
docs: Add more links to '[Environment Variables]'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Description: High-quality, ubiquitous, and portable telemetry to enable
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2.9000
+RoxygenNote: 7.3.3
 Depends: R (>= 3.6.0)
 Suggests:
     callr,

--- a/R/api.R
+++ b/R/api.R
@@ -280,6 +280,7 @@ with_active_span_safe <- with_active_span
 #' @export
 #' @usage NULL
 #' @format NULL
+#' @seealso '[Environment Variables]' needed to set OpenTelemetry logging level.
 #' @family OpenTelemetry logs API
 #' @return Not applicable.
 #' @examples
@@ -629,6 +630,7 @@ start_local_active_span_safe <- start_local_active_span
 #' @return `TRUE` is OpenTelemetry tracing is active, `FALSE` otherwise.
 #'
 #' @export
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry tracing.
 #' @family OpenTelemetry trace API
 #' @examples
 #' fun <- function() {
@@ -668,6 +670,7 @@ is_tracing_enabled_safe <- is_tracing_enabled
 #' @return `TRUE` is OpenTelemetry logging is active, `FALSE` otherwise.
 #'
 #' @export
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry logging.
 #' @family OpenTelemetry logs API
 #' @examples
 #' fun <- function() {
@@ -707,6 +710,7 @@ is_logging_enabled_safe <- is_logging_enabled
 #' `FALSE` otherwise.
 #'
 #' @export
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry recording.
 #' @family OpenTelemetry metrics API
 #' @examples
 #' fun <- function() {
@@ -745,6 +749,7 @@ is_measuring_enabled_safe <- is_measuring_enabled
 #' @return The logger, invisibly.
 #'
 #' @export
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry logging.
 #' @family OpenTelemetry logs API
 #' @examples
 #' host <- "my.db.host"
@@ -941,6 +946,7 @@ log_fatal_safe <- log_fatal
 #'
 #' @return The counter object ([otel_counter]), invisibly.
 #'
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry recording.
 #' @family OpenTelemetry metrics instruments
 #' @family OpenTelemetry metrics API
 #' @export
@@ -984,6 +990,7 @@ counter_add_safe <- counter_add
 #'
 #' @return The up-down counter object ([otel_up_down_counter]), invisibly.
 #'
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry recording.
 #' @family OpenTelemetry metrics instruments
 #' @family OpenTelemetry metrics API
 #' @export
@@ -1027,6 +1034,7 @@ up_down_counter_add_safe <- up_down_counter_add
 #' @return The histogram object ([otel_histogram]), invisibly.
 #'
 #' @export
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry recording.
 #' @family OpenTelemetry metrics instruments
 #' @family OpenTelemetry metrics API
 #' @examples
@@ -1069,6 +1077,7 @@ histogram_record_safe <- histogram_record
 #' @return The gauge object ([otel_gauge]), invisibly.
 #'
 #' @export
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry recording.
 #' @family OpenTelemetry metrics instruments
 #' @family OpenTelemetry metrics API
 #' @examples

--- a/R/docs.R
+++ b/R/docs.R
@@ -126,7 +126,7 @@ NULL
 #' @name Zero Code Instrumentation
 #' @rdname zci
 #' @family OpenTelemetry trace API
-#' @seealso [Environment Variables]
+#' @seealso '[Environment Variables]' needed to enable OpenTelemetry recording.
 #' @return Not applicable.
 #' @aliases OTEL_R_INSTRUMENT_PKGS
 #' @examples

--- a/R/logger-provider-noop.R
+++ b/R/logger-provider-noop.R
@@ -12,7 +12,7 @@
 #'
 #' Typically the logger provider is created automatically, at the first
 #' [log()] call. otel decides which logger provider class to use based on
-#' [Environment Variables].
+#' '[Environment Variables]'.
 #'
 #' # Implementations
 #'

--- a/R/meter-provider-noop.R
+++ b/R/meter-provider-noop.R
@@ -14,7 +14,7 @@
 #' Typically the meter provider is created automatically, at the first
 #' [counter_add()], [up_down_counter_add()], [histogram_record()],
 #' [gauge_record()] or [get_meter()] call. otel decides which meter
-#' provider class to use based on [Environment Variables].
+#' provider class to use based on '[Environment Variables]'.
 #'
 #' # Implementations
 #'

--- a/R/tracer-provider-noop.R
+++ b/R/tracer-provider-noop.R
@@ -12,7 +12,7 @@
 #'
 #' Typically the tracer provider is created automatically, at the first
 #' [start_local_active_span()] or [start_span()] call. otel decides which
-#' tracer provider class to use based on [Environment Variables].
+#' tracer provider class to use based on '[Environment Variables]'.
 #'
 #' # Implementations
 #'

--- a/man/counter_add.Rd
+++ b/man/counter_add.Rd
@@ -29,6 +29,8 @@ Increase an OpenTelemetry counter
 otel::counter_add("total-session-count", 1)
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry recording.
+
 Other OpenTelemetry metrics instruments: 
 \code{\link{gauge_record}()},
 \code{\link{histogram_record}()},

--- a/man/gauge_record.Rd
+++ b/man/gauge_record.Rd
@@ -29,6 +29,8 @@ Record a value of an OpenTelemetry gauge
 otel::gauge_record("temperature", 27)
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry recording.
+
 Other OpenTelemetry metrics instruments: 
 \code{\link{counter_add}()},
 \code{\link{histogram_record}()},

--- a/man/gettingstarted.Rd
+++ b/man/gettingstarted.Rd
@@ -190,7 +190,7 @@ a local or remote OpenTelemetry collector.
 
 I suggest you use \href{https://github.com/ymtdzzz/otel-tui}{\code{otel-tui}},
 a terminal OpenTelemetry viewer. To configure it, use the \code{http} exporter,
-see \link{Environment Variables}:
+see '\link{Environment Variables}':
 
 \if{html}{\out{<div class="sourceCode sh">}}\preformatted{OTEL_TRACES_EXPORTER=http R -q
 }\if{html}{\out{</div>}}

--- a/man/histogram_record.Rd
+++ b/man/histogram_record.Rd
@@ -29,6 +29,8 @@ Record a value of an OpenTelemetry histogram
 otel::histogram_record("response-time", 0.2)
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry recording.
+
 Other OpenTelemetry metrics instruments: 
 \code{\link{counter_add}()},
 \code{\link{gauge_record}()},

--- a/man/is_logging_enabled.Rd
+++ b/man/is_logging_enabled.Rd
@@ -32,6 +32,8 @@ fun <- function() {
 }
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry logging.
+
 Other OpenTelemetry logs API: 
 \code{\link{log}()},
 \code{\link{log_severity_levels}}

--- a/man/is_measuring_enabled.Rd
+++ b/man/is_measuring_enabled.Rd
@@ -31,6 +31,8 @@ fun <- function() {
 }
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry recording.
+
 Other OpenTelemetry metrics API: 
 \code{\link{counter_add}()},
 \code{\link{gauge_record}()},

--- a/man/is_tracing_enabled.Rd
+++ b/man/is_tracing_enabled.Rd
@@ -32,6 +32,8 @@ fun <- function() {
 }
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry tracing.
+
 Other OpenTelemetry trace API: 
 \code{\link{Zero Code Instrumentation}},
 \code{\link{end_span}()},

--- a/man/log.Rd
+++ b/man/log.Rd
@@ -67,6 +67,8 @@ port <- 6667
 otel::log("Connecting to database at {host}:{port}")
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry logging.
+
 Other OpenTelemetry logs API: 
 \code{\link{is_logging_enabled}()},
 \code{\link{log_severity_levels}}

--- a/man/log_severity_levels.Rd
+++ b/man/log_severity_levels.Rd
@@ -16,6 +16,8 @@ both forms as severity levels, but the text form is more readable.
 log_severity_levels
 }
 \seealso{
+'\link{Environment Variables}' needed to set OpenTelemetry logging level.
+
 Other OpenTelemetry logs API: 
 \code{\link{is_logging_enabled}()},
 \code{\link{log}()}

--- a/man/otel_logger_provider.Rd
+++ b/man/otel_logger_provider.Rd
@@ -18,7 +18,7 @@ Usually there is a single logger provider for an R app or script.
 
 Typically the logger provider is created automatically, at the first
 \code{\link[=log]{log()}} call. otel decides which logger provider class to use based on
-\link{Environment Variables}.
+'\link{Environment Variables}'.
 }
 \section{Implementations}{
 Note that this list is updated manually and may be incomplete.

--- a/man/otel_meter_provider.Rd
+++ b/man/otel_meter_provider.Rd
@@ -20,7 +20,7 @@ Usually there is a single meter provider for an R app or script.
 Typically the meter provider is created automatically, at the first
 \code{\link[=counter_add]{counter_add()}}, \code{\link[=up_down_counter_add]{up_down_counter_add()}}, \code{\link[=histogram_record]{histogram_record()}},
 \code{\link[=gauge_record]{gauge_record()}} or \code{\link[=get_meter]{get_meter()}} call. otel decides which meter
-provider class to use based on \link{Environment Variables}.
+provider class to use based on '\link{Environment Variables}'.
 }
 \section{Implementations}{
 Note that this list is updated manually and may be incomplete.

--- a/man/otel_tracer_provider.Rd
+++ b/man/otel_tracer_provider.Rd
@@ -18,7 +18,7 @@ Usually there is a single tracer provider for an R app or script.
 
 Typically the tracer provider is created automatically, at the first
 \code{\link[=start_local_active_span]{start_local_active_span()}} or \code{\link[=start_span]{start_span()}} call. otel decides which
-tracer provider class to use based on \link{Environment Variables}.
+tracer provider class to use based on '\link{Environment Variables}'.
 }
 \section{Implementations}{
 Note that this list is updated manually and may be incomplete.

--- a/man/up_down_counter_add.Rd
+++ b/man/up_down_counter_add.Rd
@@ -36,6 +36,8 @@ Increase or decrease an OpenTelemetry up-down counter
 otel::up_down_counter_add("session-count", 1)
 }
 \seealso{
+'\link{Environment Variables}' needed to enable OpenTelemetry recording.
+
 Other OpenTelemetry metrics instruments: 
 \code{\link{counter_add}()},
 \code{\link{gauge_record}()},

--- a/man/zci.Rd
+++ b/man/zci.Rd
@@ -39,7 +39,7 @@ overwrites the first.
 # OTEL_TRACES_EXPORTER=http OTEL_INSTRUMENT_R_PKGS=dplyr,tidyr R -q -f script.R
 }
 \seealso{
-\link{Environment Variables}
+'\link{Environment Variables}' needed to enable OpenTelemetry recording.
 
 Other OpenTelemetry trace API: 
 \code{\link{end_span}()},

--- a/tools/dox/gettingstarted.Rmd
+++ b/tools/dox/gettingstarted.Rmd
@@ -183,7 +183,7 @@ a local or remote OpenTelemetry collector.
 
 I suggest you use [`otel-tui`](https://github.com/ymtdzzz/otel-tui),
 a terminal OpenTelemetry viewer. To configure it, use the `http` exporter,
-see [Environment Variables]:
+see '[Environment Variables]':
 
 ```sh
 OTEL_TRACES_EXPORTER=http R -q


### PR DESCRIPTION
Given `'[Environment Variables]'` are required to record, I feel more links to the envvars are a good thing to add.

Happy to change approach / wording.